### PR TITLE
Update manifests/params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -108,7 +108,7 @@ class mcollective::params {
     default => '/var/log/mcollective.log',
   }
 
-  $port = '6163'
+  $port = '61613'
   $protocol = 'tcp'
 
   # General Settings


### PR DESCRIPTION
tcp port same as stomp port, so defaults are working correctly
