### PR TITLE
Ability to set package provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,9 @@
 # [*filter_factsyml*]
 #   Define the filter to use for the default template of the facts yml
 #
+# [*package_provider*]
+#   The Provider to use for the package resource
+#
 #
 # Standard class parameters
 #
@@ -302,6 +305,7 @@ class mcollective (
   $template_client        = params_lookup( 'template_client' ),
   $template_factsyml      = params_lookup( 'template_factsyml' ),
   $filter_factsyml        = params_lookup( 'filter_factsyml' ),
+  $package_provider       = params_lookup( 'package_provider' ),
   $template_stomp_server  = params_lookup( 'template_stomp_server' ),
   $daemonize              = params_lookup( 'daemonize' ),
   $my_class               = params_lookup( 'my_class' ),
@@ -455,7 +459,8 @@ class mcollective (
   }
 
   package { $mcollective::package:
-    ensure => $mcollective::manage_package,
+    provider => $mcollective::package_provider,
+    ensure   => $mcollective::manage_package,
   }
 
   service { 'mcollective':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,10 @@ class mcollective::params {
     default => 'mcollective-client',
   }
 
+  $package_provider   = $::operatingsystem ? {
+    default => undef,
+  }
+
   $config_file_client = $::operatingsystem ? {
     default => '/etc/mcollective/client.cfg',
   }


### PR DESCRIPTION
Hello,

We use GEM as the package provider for some of our servers. I think eventually I need to split it out to install.pp like the Elasticsearch module, but right now it works fine until we can get time to do this.

Default is undef which keeps backwards compatibility for existing users.
