### PR TITLE
Debian stomp package name changed

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,7 +63,7 @@ class mcollective::params {
   }
 
   $package_dependencies = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => 'libstomp-ruby',
+    /(?i:Debian|Ubuntu|Mint)/ => 'ruby-stomp',
     default                   => undef,
   }
 


### PR DESCRIPTION
Debian is changing ruby gems packages names from lib_-ruby to ruby-_, and turning old packages into transitionals.

Now libstomp-ruby is, thereafter, ruby-stomp
