### PR TITLE
Allow mcollective to access mcollective.nodes queue.

### DIFF
--- a/templates/ubuntu_activemq.xml.erb
+++ b/templates/ubuntu_activemq.xml.erb
@@ -40,6 +40,7 @@
               <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
               <authorizationEntry topic="mcollective.>" write="admins" read="admins" admin="admins" />
               <authorizationEntry topic="mcollective.>" write="admins" read="admins" admin="admins" />
+              <authorizationEntry queue="mcollective.nodes" read="mcollective" admin="mcollective" />
               <authorizationEntry topic="mcollective.*.reply" write="mcollective" admin="mcollective" />
               <authorizationEntry queue="mcollective.reply.>" write="mcollective" admin="mcollective" />
               <authorizationEntry topic="mcollective.*.agent" read="mcollective" admin="mcollective" />


### PR DESCRIPTION
Add missing authorization entry.
