### PR TITLE
Allow to configure periodic registration for mcollective servers.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,10 @@
 # [*server_identity*]
 #   The identity of mcollective server. Defaults to hostname.
 #
+# [*register_interval*]
+#   How long (in seconds) to wait between registration messages.
+#   Default to 0, disabling registration.
+#
 # [*package_client*]
 #   The name of mcollective client package
 #
@@ -312,6 +316,7 @@ class mcollective (
   $install_plugins        = params_lookup( 'install_plugins' ),
   $psk                    = params_lookup( 'psk' ),
   $server_identity        = params_lookup( 'server_identity' ),
+  $register_interval      = params_lookup( 'register_interval' ),
   $package_client         = params_lookup( 'package_client' ),
   $config_file_client     = params_lookup( 'config_file_client' ),
   $template_client        = params_lookup( 'template_client' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,8 @@ class mcollective::params {
 
   $server_identity = $::fqdn
 
+  $register_interval = 0
+
   $package_client = $::operatingsystem ? {
     default => 'mcollective-client',
   }

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -23,6 +23,9 @@ plugin.activemq.pool.1.port = <%= scope.lookupvar('mcollective::stomp_port') %>
 plugin.activemq.pool.1.user = <%= scope.lookupvar('mcollective::stomp_user') %>
 plugin.activemq.pool.1.password = <%= scope.lookupvar('mcollective::stomp_password') %>
 
+# Registration
+registerinterval = <%= scope.lookupvar('mcollective::register_interval') %>
+
 # Facts
 factsource = yaml
 plugin.yaml = /etc/mcollective/facts.yaml


### PR DESCRIPTION
Allow to configure periodic registration for mcollective servers to avoid disappearing nodes.
Default to 0 (disabling registration)
http://docs.puppetlabs.com/mcollective/configure/server.html#node-registration
