### PR TITLE
Allow to configure ActiveMQ systemUsage limits.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,15 @@
 # [*stomp_admin_password*]
 #   The password for the stomp_admin_user
 #
+# [*memory_usage*]
+#   ActiveMQ memoryUsage configuration
+#
+# [*store_usage*]
+#   ActiveMQ storeUsage configuration
+#
+# [*temp_usage*]
+#   ActiveMQ tempUsage configuration
+#
 # [*install_client*]
 #   Set to true if you want to install mcollective client
 #   (With mcollective client you manage the whole mcollective
@@ -307,6 +316,9 @@ class mcollective (
   $client_stomp_password  = params_lookup( 'client_stomp_password' ),
   $stomp_admin            = params_lookup( 'stomp_admin' ),
   $stomp_admin_password   = params_lookup( 'stomp_admin_password' ),
+  $memory_usage           = params_lookup( 'memory_usage' ),
+  $store_usage            = params_lookup( 'store_usage' ),
+  $temp_usage             = params_lookup( 'temp_usage' ),
   $install_client         = params_lookup( 'install_client' ),
   $install_stomp_server   = params_lookup( 'install_stomp_server' ),
   $install_plugins        = params_lookup( 'install_plugins' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,10 @@ class mcollective::params {
   $stomp_admin = 'mcollective_admin'
   $stomp_admin_password = 'secret!'
 
+  $memory_usage = '100 mb'
+  $store_usage = '1 gb'
+  $temp_usage = '100 mb'
+
   $install_client = false
   $install_stomp_server = false
   $install_plugins = true

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -129,13 +129,13 @@
         <systemUsage>
             <systemUsage>
                 <memoryUsage>
-                    <memoryUsage limit="100 mb"/>
+                    <memoryUsage limit="<%= scope.lookupvar('mcollective::memory_usage') %>"/>
                 </memoryUsage>
                 <storeUsage>
-                    <storeUsage limit="1 gb"/>
+                    <storeUsage limit="<%= scope.lookupvar('mcollective::store_usage') %>"/>
                 </storeUsage>
                 <tempUsage>
-                    <tempUsage limit="100 mb"/>
+                    <tempUsage limit="<%= scope.lookupvar('mcollective::temp_usage') %>"/>
                 </tempUsage>
             </systemUsage>
         </systemUsage>

--- a/templates/ubuntu_activemq.xml.erb
+++ b/templates/ubuntu_activemq.xml.erb
@@ -57,13 +57,13 @@
     <systemUsage>
       <systemUsage>
         <memoryUsage>
-          <memoryUsage limit="100 mb"/>
+          <memoryUsage limit="<%= scope.lookupvar('mcollective::memory_usage') %>"/>
         </memoryUsage>
         <storeUsage>
-          <storeUsage limit="1 gb"/>
+          <storeUsage limit="<%= scope.lookupvar('mcollective::store_usage') %>"/>
         </storeUsage>
         <tempUsage>
-          <tempUsage limit="100 mb"/>
+          <tempUsage limit="<%= scope.lookupvar('mcollective::temp_usage') %>"/>
         </tempUsage>
       </systemUsage>
     </systemUsage>


### PR DESCRIPTION
Allow to configure ActiveMQ systemUsage limits. Defaults to what was hard-coded previously.
See http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage 
