### PR TITLE
Allow servers to write mcollective.registration.agent, required for node registration.

### DIFF
--- a/templates/ubuntu_activemq.xml.erb
+++ b/templates/ubuntu_activemq.xml.erb
@@ -44,6 +44,7 @@
               <authorizationEntry topic="mcollective.*.reply" write="mcollective" admin="mcollective" />
               <authorizationEntry queue="mcollective.reply.>" write="mcollective" admin="mcollective" />
               <authorizationEntry topic="mcollective.*.agent" read="mcollective" admin="mcollective" />
+              <authorizationEntry topic="mcollective.registration.agent" write="mcollective" read="mcollective" admin="mcollective" />
               <authorizationEntry topic="mcollective.registration.command" write="mcollective" read="mcollective" admin="mcollective" />
               <authorizationEntry topic="mcollective.*.command" read="mcollective" admin="mcollective" />
               <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>


### PR DESCRIPTION
Set required activemq authorization for node registration for debian-based OS.
