### PR TITLE
Remove deprecated mcollective config options / Remove attribute from activemq.xml file

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -19,7 +19,7 @@
     <!-- 
         The <broker> element is used to configure the ActiveMQ broker. 
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.base}/data" destroyApplicationContextOnStop="true">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.base}/data">
  
         <!--
           For better performances use VM cursor and small memory limit.

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -1,6 +1,5 @@
 # File Managed by Puppet
 
-topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
 libdir = <%= scope.lookupvar('mcollective::data_dir') %>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -1,6 +1,5 @@
 # File Managed by Puppet
 
-topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
 libdir = <%= scope.lookupvar('mcollective::data_dir') %>


### PR DESCRIPTION
Removing option from activemq.xml.erb that causes ActiveMQ to not start

Removing deprecated warnings from server.cfg and client.cfg
